### PR TITLE
[fix] Add public scope on Image+SFSymbols.

### DIFF
--- a/Sources/SFUserFriendlySymbols/Initializer/Image+SFSymbols.swift
+++ b/Sources/SFUserFriendlySymbols/Initializer/Image+SFSymbols.swift
@@ -11,7 +11,7 @@
 import SwiftUI
 
 @available(iOS 13.0, macCatalyst 13.0, macOS 11.0, tvOS 13.0, watchOS 6.0, *)
-extension SwiftUI.Image {
+public extension SwiftUI.Image {
     
     /// Creates a image with the given symbol.
     ///


### PR DESCRIPTION
There is a bug that Image+SFSymbols doesn't have `public` scope.
Fixed it